### PR TITLE
Update metadata in layout.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,22 +10,6 @@ const inter = Inter({ subsets: ["latin"] });
 export const metadata: Metadata = {
   title: "HT Part Picker",
   description: "The simplest way to put together a Home Theater parts list.",
-  openGraph: {
-    title: "HT Part Picker",
-    description: "The simplest way to put together a Home Theater parts list.",
-    url: "https://htpartpicker.com",
-    siteName: "htpartpicker.com",
-    images: [
-      {
-        url: "https://www.htpartpicker.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fhome-theater.893ed986.png&w=1080&q=75", // Must be an absolute URL
-        width: 1080,
-        height: 1080,
-        alt: "Home Theater",
-      },
-    ],
-    locale: "en_US",
-    type: "website",
-  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
This pull request updates the metadata in the layout.tsx file. The openGraph section has been removed and the metadata now only includes the title and description.