### PR TITLE
Add metadataBase URL to layout.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ const inter = Inter({ subsets: ["latin"] });
 export const metadata: Metadata = {
   title: "HT Part Picker",
   description: "The simplest way to put together a Home Theater parts list.",
+  metadataBase: new URL("https://htpartpicker.com"),
 };
 
 export default function RootLayout({


### PR DESCRIPTION
This pull request adds the metadataBase URL to the layout.tsx file, allowing for easier access to the Home Theater Part Picker website.