### PR TITLE
Fix error handling in useClientPromise function

### DIFF
--- a/hooks/useClientPromise.tsx
+++ b/hooks/useClientPromise.tsx
@@ -9,6 +9,7 @@ export function useClientPromise<T>(
       if (!foo.success) throw foo.error;
       return foo.data;
     } catch (error) {
+      if (typeof error === "string") throw error;
       throw "The server is not available. Please try again later.";
     }
   };


### PR DESCRIPTION
This pull request fixes the error handling in the useClientPromise function. Previously, if the error was not a new error instance, it would be overwritten with a generic error message. This PR ensures that the original error is kept if it is not a new error instance.